### PR TITLE
chore: update to new ceramic_event builder api

### DIFF
--- a/it/docker-compose.yml
+++ b/it/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3'
 services:
   ceramic-service:
-    image: ceramicnetwork/js-ceramic:5.1.0-rc.1
+    image: ceramicnetwork/js-ceramic:latest
     volumes:
       - ./data:/root/.ceramic
     ports:

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,7 +1,7 @@
-use crate::query::FilterQuery;
+use crate::{jws::Jws, query::FilterQuery};
 use ceramic_event::{
-    Base64String, Base64UrlString, Jws, MultiBase32String, MultiBase36String, StreamId,
-    StreamIdType,
+    unvalidated::signed, Base64String, Base64UrlString, MultiBase32String, MultiBase36String,
+    StreamId, StreamIdType,
 };
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
@@ -39,7 +39,7 @@ pub struct BlockData<T: Serialize> {
     pub data: Option<T>,
     /// Signature for block
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub jws: Option<Jws>,
+    pub jws: Option<signed::Envelope>,
     /// IPFS Linked Block
     #[serde(skip_serializing_if = "Option::is_none")]
     pub linked_block: Option<Base64String>,

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,7 +1,6 @@
 use crate::{jws::Jws, query::FilterQuery};
 use ceramic_event::{
-    unvalidated::signed, Base64String, Base64UrlString, MultiBase32String, MultiBase36String,
-    StreamId, StreamIdType,
+    Base64String, Base64UrlString, MultiBase32String, MultiBase36String, StreamId, StreamIdType,
 };
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
@@ -39,7 +38,7 @@ pub struct BlockData<T: Serialize> {
     pub data: Option<T>,
     /// Signature for block
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub jws: Option<signed::Envelope>,
+    pub jws: Option<Jws>,
     /// IPFS Linked Block
     #[serde(skip_serializing_if = "Option::is_none")]
     pub linked_block: Option<Base64String>,

--- a/src/jws.rs
+++ b/src/jws.rs
@@ -1,0 +1,131 @@
+use std::{collections::BTreeMap, str::FromStr};
+
+use ceramic_event::{
+    ssi, unvalidated::signed::Signer, Base64String, Base64UrlString, Cid, MultiBase32String,
+};
+use serde::{Deserialize, Serialize};
+
+/// The fields associated with the signature used to sign a JWS
+#[derive(Debug, Serialize, Deserialize)]
+pub struct JwsSignature {
+    /// Protected header
+    pub protected: Option<Base64String>,
+    /// Signature
+    pub signature: Base64UrlString,
+}
+
+/// Builder used to create JWS
+pub struct JwsBuilder<S> {
+    signer: S,
+    additional: BTreeMap<String, serde_json::Value>,
+}
+
+impl<S: Signer> JwsBuilder<S> {
+    pub fn new(signer: S) -> Self {
+        Self {
+            signer,
+            additional: BTreeMap::new(),
+        }
+    }
+
+    pub fn with_additional(mut self, key: String, value: serde_json::Value) -> Self {
+        self.additional.insert(key, value);
+        self
+    }
+
+    pub fn replace_additional(mut self, additional: BTreeMap<String, serde_json::Value>) -> Self {
+        self.additional = additional;
+        self
+    }
+
+    pub fn build_for_cid(self, cid: &Cid) -> anyhow::Result<Jws> {
+        let cid_str = Base64UrlString::from_cid(cid);
+        let link = MultiBase32String::try_from(cid)?;
+        Jws::new(&self.signer, cid_str, Some(link), self.additional)
+    }
+
+    pub fn build_for_data<T: Serialize>(self, input: &T) -> anyhow::Result<Jws> {
+        let input = serde_json::to_vec(input)?;
+        let input = Base64UrlString::from(input);
+        Jws::new(&self.signer, input, None, self.additional)
+    }
+}
+
+/// A JWS object
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Jws {
+    /// Link to CID that contains encoded data
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub link: Option<MultiBase32String>,
+    /// Encoded data
+    pub payload: Base64UrlString,
+    /// The signatures of the JWS
+    pub signatures: Vec<JwsSignature>,
+}
+
+impl Jws {
+    /// Create a builder for Jws objects
+    pub fn builder<S: Signer>(signer: S) -> JwsBuilder<S> {
+        JwsBuilder::new(signer)
+    }
+
+    /// Creates a new JWS from a payload that has already been serialized to Base64UrlString
+    pub fn new(
+        signer: &impl Signer,
+        input: Base64UrlString,
+        link: Option<MultiBase32String>,
+        additional_parameters: BTreeMap<String, serde_json::Value>,
+    ) -> anyhow::Result<Self> {
+        let alg = signer.algorithm();
+        let header = ssi::jws::Header {
+            algorithm: alg,
+            type_: Some("JWT".to_string()),
+            key_id: Some(signer.id().id.clone()),
+            additional_parameters,
+            ..Default::default()
+        };
+        // creates compact signature of protected.signature
+        let header_str = Base64String::from(serde_json::to_vec(&header)?);
+        let signing_input = format!("{}.{}", header_str.as_ref(), input.as_ref());
+        let signed = signer.sign(signing_input.as_bytes())?;
+        Ok(Self {
+            link,
+            payload: input,
+            signatures: vec![JwsSignature {
+                protected: Some(header_str),
+                signature: signed.into(),
+            }],
+        })
+    }
+
+    /// Get the payload of this jws
+    pub fn payload(&self) -> &Base64UrlString {
+        &self.payload
+    }
+
+    /// Get the additional parameters of the jws signature
+    pub fn additional(&self) -> anyhow::Result<BTreeMap<String, serde_json::Value>> {
+        let first = self
+            .signatures
+            .first()
+            .ok_or_else(|| anyhow::anyhow!("No signatures"))?;
+        let protected = first
+            .protected
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("No protected header"))?;
+        let protected = serde_json::from_slice::<ssi::jws::Header>(&protected.to_vec()?)?;
+        Ok(protected.additional_parameters)
+    }
+
+    /// Get the capability field for this jws
+    pub fn capability(&self) -> anyhow::Result<Cid> {
+        let additional = self.additional()?;
+        let cap = additional
+            .get("cap")
+            .ok_or_else(|| anyhow::anyhow!("No cap"))?
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("cap is not a string"))?;
+        let cid = Cid::from_str(cap)?;
+        Ok(cid)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,9 +102,9 @@ impl<S: Signer + Sync> CeramicHttpClient<S> {
             .build();
         let event = Event::from_payload(commit.into(), &self.signer)?;
         let controllers: Vec<_> = vec![controller];
+        let jws = Jws::builder(&self.signer).build_for_cid(&event.payload_cid())?;
         let data = Base64String::from(event.encode_payload()?);
         let model = Base64String::from(PARENT_STREAM_ID.to_vec());
-        let (envelope, _payload) = event.into_parts();
 
         Ok(api::CreateRequest {
             r#type: StreamIdType::Model,
@@ -115,7 +115,7 @@ impl<S: Signer + Sync> CeramicHttpClient<S> {
                     model,
                 },
                 linked_block: Some(data.clone()),
-                jws: Some(envelope),
+                jws: Some(jws),
                 data: Some(data),
                 cacao_block: None,
             },
@@ -215,7 +215,7 @@ impl<S: Signer + Sync> CeramicHttpClient<S> {
         let event = Event::from_payload(commit.into(), &self.signer)?;
         let controllers: Vec<_> = vec![controller];
         let data = Base64String::from(event.encode_payload()?);
-        let (envelope, _payload) = event.into_parts();
+        let jws = Jws::builder(&self.signer).build_for_cid(&event.payload_cid())?;
 
         Ok(api::CreateRequest {
             r#type: StreamIdType::ModelInstanceDocument,
@@ -226,7 +226,7 @@ impl<S: Signer + Sync> CeramicHttpClient<S> {
                     model,
                 },
                 linked_block: Some(data.clone()),
-                jws: Some(envelope),
+                jws: Some(jws),
                 data: Some(data),
                 cacao_block: None,
             },
@@ -257,7 +257,7 @@ impl<S: Signer + Sync> CeramicHttpClient<S> {
             let controllers: Vec<_> = vec![controller];
             let data = Base64String::from(event.encode_payload()?);
             let stream = MultiBase36String::try_from(&get.stream_id)?;
-            let (envelope, _payload) = event.into_parts();
+            let jws = Jws::builder(&self.signer).build_for_cid(&event.payload_cid())?;
             Ok(api::UpdateRequest {
                 r#type: StreamIdType::ModelInstanceDocument,
                 block: api::BlockData {
@@ -267,7 +267,7 @@ impl<S: Signer + Sync> CeramicHttpClient<S> {
                         model,
                     },
                     linked_block: Some(data.clone()),
-                    jws: Some(envelope),
+                    jws: Some(jws),
                     data: Some(data),
                     cacao_block: None,
                 },


### PR DESCRIPTION
The Jws from ceramic_core is copied to here as it has different needs than the one we need to build events. 

For example building events must NOT have the `typ` set to `JWK` (not sure why but that is how its implemented in js-ceramic). 

So in short the Jws type that lives here is for signing admin api requests and only admin api requests. 

Updated the docker image we use in tests as it was failing with an older 5.1-rc version before.