### PR TITLE
chore: need to publicly export moved Jws and JwsBuilder for consumers

### DIFF
--- a/src/jws.rs
+++ b/src/jws.rs
@@ -21,6 +21,7 @@ pub struct JwsBuilder<S> {
 }
 
 impl<S: Signer> JwsBuilder<S> {
+    /// Create a new JwsBuilder with a signer
     pub fn new(signer: S) -> Self {
         Self {
             signer,
@@ -28,22 +29,26 @@ impl<S: Signer> JwsBuilder<S> {
         }
     }
 
+    /// Add additional information to the JWS
     pub fn with_additional(mut self, key: String, value: serde_json::Value) -> Self {
         self.additional.insert(key, value);
         self
     }
 
+    /// Replace the additional information in the JWS
     pub fn replace_additional(mut self, additional: BTreeMap<String, serde_json::Value>) -> Self {
         self.additional = additional;
         self
     }
 
+    /// Build a JWS for a CID. This is used to define a link to other data.
     pub fn build_for_cid(self, cid: &Cid) -> anyhow::Result<Jws> {
         let cid_str = Base64UrlString::from_cid(cid);
         let link = MultiBase32String::try_from(cid)?;
         Jws::new(&self.signer, cid_str, Some(link), self.additional)
     }
 
+    /// Build a JWS for with data as the payload.
     pub fn build_for_data<T: Serialize>(self, input: &T) -> anyhow::Result<Jws> {
         let input = serde_json::to_vec(input)?;
         let input = Base64UrlString::from(input);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,13 +16,13 @@ use ceramic_event::{
     },
     Base64String, Cid, MultiBase36String, StreamId, StreamIdType,
 };
-use jws::Jws;
 use serde::Serialize;
 use std::str::FromStr;
 
 use crate::api::{ModelData, PARENT_STREAM_ID, SEP};
 pub use ceramic_event;
 pub use json_patch;
+pub use jws::{Jws, JwsBuilder};
 pub use model_definition::{
     GetRootSchema, ModelAccountRelation, ModelDefinition, ModelRelationDefinition,
     ModelViewDefinition,


### PR DESCRIPTION
I missed this in #18. Needed for Keramik and others to build events. I didn't export the signer, as we can pull it in through ceramic_event/ceramic_core but it could maybe be re-exported. 